### PR TITLE
Added pre-scan align

### DIFF
--- a/control/controller.py
+++ b/control/controller.py
@@ -96,7 +96,7 @@ class Controller:
             pass
 
         if align_pre_scan:
-            await asyncio.gather(*[no_scan_align(v,TrackPieceTypes.START) for v in self.vehicles])
+            await asyncio.gather(*[no_scan_align(v,TrackPieceTypes.FINISH) for v in self.vehicles])
             await asyncio.sleep(1)
             pass
 
@@ -110,10 +110,13 @@ class Controller:
 
         scanner = Scanner(scan_vehicle)
         
+        await scan_vehicle.setSpeed(150)
+        await asyncio.sleep(1)
+        await scan_vehicle.stop()
+
         if not align_pre_scan:
             tasks = [asyncio.create_task(simul_align(v)) for v in temp_vehicles]
             pass
-
         self.map = await scanner.scan()
 
         if not align_pre_scan: 

--- a/control/scanner.py
+++ b/control/scanner.py
@@ -43,7 +43,6 @@ class Scanner:
         await self.vehicle.stop()
 
         reorder_map(self.map)
-        print(self.map)
 
         return self.map
         pass

--- a/vehicle.py
+++ b/vehicle.py
@@ -157,7 +157,7 @@ class Vehicle:
 
     async def stop(self):
         """Stops the Supercar"""
-        await self.setSpeed(0,1000)
+        await self.setSpeed(0)
         pass
 
     async def change_lane(self, lane : _Lane, horizontalSpeed : int = 300, horizontalAcceleration : int = 300, *, _hopIntent : int = 0x0, _tag : int = 0x0):


### PR DESCRIPTION
Added optional parameter `align_pre_scan`, which, if set to True, makes the vehicles align to START before the scan is executed. It also disables alignment after the scan as it is no longer needed