### PR TITLE
Always align at segment after START

### DIFF
--- a/anki/control/controller.py
+++ b/anki/control/controller.py
@@ -152,7 +152,7 @@ class Controller:
             pass
 
         if align_pre_scan: # Aligning before scanning if enabled. This allows the vehicles to be placed anywhere on the map
-            await asyncio.gather(*[noScanAlign(v,TrackPieceTypes.FINISH) for v in self.vehicles])
+            await asyncio.gather(*[noScanAlign(v,TrackPieceTypes.START) for v in self.vehicles])
             await asyncio.sleep(1)
             pass
 

--- a/anki/control/scanner.py
+++ b/anki/control/scanner.py
@@ -28,6 +28,7 @@ class Scanner:
         track_types = [] # This keeps track of the types we've visited (could also be a set, but TrackPieceType didn't have hashes back then)
         def watcher():
             track = self.vehicle._current_track_piece
+            print(track)
             if track is not None: # track might be None for the first time this event is called
                 self.map.append(track)
                 track_types.append(track.type)

--- a/anki/control/scanner.py
+++ b/anki/control/scanner.py
@@ -28,7 +28,6 @@ class Scanner:
         track_types = [] # This keeps track of the types we've visited (could also be a set, but TrackPieceType didn't have hashes back then)
         def watcher():
             track = self.vehicle._current_track_piece
-            print(track)
             if track is not None: # track might be None for the first time this event is called
                 self.map.append(track)
                 track_types.append(track.type)

--- a/anki/vehicle.py
+++ b/anki/vehicle.py
@@ -268,11 +268,11 @@ class Vehicle:
         + Optional speed: The speed the vehicle should travel at during alignment"""
         await self.setSpeed(speed)
         track_piece = None
-        while track_piece is None or track_piece.type != const.TrackPieceTypes.START: # Wait until at START
+        while track_piece is None or track_piece.type != const.TrackPieceTypes.FINISH: # Wait until at START
             track_piece = await self.wait_for_track_change()
             pass
 
-        self._position = 0 # Update position to be at START
+        self._position = len(self.map)-1 # Update position to be at FINISH
 
         await self.stop()
         pass


### PR DESCRIPTION
This branch changes `Vehicle.align`, `Controller.scan`, and `Scanner.scan` to be consistent to each other always aligning after the START segment. `Controller.scan` can only be implemented sanely this way, so for consistency this was implemented in every other alignment process.
This is a **breaking change** for some programs that may rely on the alignment process aligning before the START piece.