### PR TITLE
Allow setting a custom Vehicle as a scanner

### DIFF
--- a/anki/control/controller.py
+++ b/anki/control/controller.py
@@ -126,7 +126,7 @@ class Controller:
         pass
 
     
-    async def scan(self, align_pre_scan : bool = True) -> list[TrackPiece]:
+    async def scan(self, scan_vehicle : Vehicle = None, align_pre_scan : bool = True) -> list[TrackPiece]:
         """Assembles a digital copy of the map and adds it to every connected vehicle.
         
         ## Parameters\n
@@ -152,7 +152,10 @@ class Controller:
             pass
 
         temp_vehicles = self.vehicles.copy()
-        scan_vehicle = temp_vehicles.pop() # Take a vehicle out of the set. This allows us to use temp_vehicles as a set of all non-scannning vehicles
+        if scan_vehicle is None:
+            scan_vehicle = temp_vehicles.pop() # Take a vehicle out of the set. This allows us to use temp_vehicles as a set of all non-scannning vehicles
+        else:
+            temp_vehicles.remove(scan_vehicle) # Remove the scanning vehicle from the set if it is already passed as an argument
 
         if align_pre_scan: # Aligning before scanning if enabled. This allows the vehicles to be placed anywhere on the map
             await asyncio.gather(*[noScanAlign(v,TrackPieceTypes.FINISH) for v in self.vehicles]) # Since we're aligning BEFORE scan, we need the piece before the one we want to align in front of

--- a/anki/control/controller.py
+++ b/anki/control/controller.py
@@ -130,7 +130,8 @@ class Controller:
         """Assembles a digital copy of the map and adds it to every connected vehicle.
         
         ## Parameters\n
-        Optional `align_pre_scan`: When set to True, the supercars can start from any position on the map and align automatically before scanning. Disabling this means your supercars need to start between START and FINISH
+        + Optional `scan_vehicle`: When passed a Vehicle object, this Vehicle will be used as a scanner. Otherwise it will be selected automatically.
+        + Optional `align_pre_scan`: When set to True, the supercars can start from any position on the map and align automatically before scanning. Disabling this means your supercars need to start between START and FINISH
 
         ## Returns\n
         A list of track pieces representing the scanned in map.


### PR DESCRIPTION
Add optional `scan_vehicle` parameter to `Controller.scan` allowing users to pass a `Vehicle` object to be used as the scanner.

Internally also changing a few lines in the method to allow for use of this parameter.