### PR TITLE
Changed TrackPiece to be a dataclass

### DIFF
--- a/utility/track_pieces.py
+++ b/utility/track_pieces.py
@@ -1,23 +1,19 @@
-from .const import TrackPieceTypes
+from .const import TrackPieceType, TrackPieceTypes
+from dataclasses import dataclass, field
 
+
+@dataclass(frozen=True, slots=True)
 class TrackPiece():
-    __slots__ = ["type","loc","clockwise"]
-    def __init__(self, loc : int, piece_val : int, clockwise : int) -> None:
-        object.__setattr__(self,"type",TrackPieceTypes.try_type(piece_val))
-        object.__setattr__(self,"loc",loc)
-        object.__setattr__(self,"clockwise",clockwise > 30)
-        pass
+    loc : int
+    type : TrackPieceType
+    clockwise : bool = field(compare=False)
 
-    def __setattr__(self, name: str, value) -> None:
-        raise NotImplementedError("This instance is frozen and cannot be written to")
-        pass
-
-    def __repr__(self) -> str:
-        return f"<TrackPiece type={TrackPieceTypes.as_str(self.type)}; loc={self.loc}; clockwise={self.clockwise}>"
-        pass
-
-    def __eq__(self,other : object) -> bool:
-        if not isinstance(other,self.__class__): raise TypeError("Comparison between {0} and {1} is not possible".format(self.__class__,other.__class__))
-        return self.type is other.type and self.loc is other.loc
+    @staticmethod
+    def from_raw(loc : int, piece_val : int, clockwise : int) -> "TrackPiece":
+        return TrackPiece(
+            loc,
+            TrackPieceTypes.try_type(piece_val),
+            clockwise > 30
+        )
         pass
     pass

--- a/vehicle.py
+++ b/vehicle.py
@@ -75,7 +75,7 @@ class Vehicle:
             self._speed = speed
 
             try:
-                piece_obj = TrackPiece(loc,piece,clockwise)
+                piece_obj = TrackPiece.from_raw(loc,piece,clockwise)
             except ValueError:
                 warn(f"A TrackPiece value received from the vehicle could not be decoded. If you are running a scan, this will break it. Received: {piece}",errors.TrackPieceDecodeWarning)
                 return


### PR DESCRIPTION
Changed the TrackPiece class to use dataclasses instead of the manual freezing. This caused the constructor to change and is an internal breaking change. However, The staticmethod `TrackPiece.from_raw` is added to replace the old constructor.