### PR TITLE
Made vehicles remove themselves from the Controller when Vehicle.disconnect is called

### DIFF
--- a/anki/control/controller.py
+++ b/anki/control/controller.py
@@ -55,7 +55,7 @@ class Controller:
             vehicle_id = id(client)
             pass
 
-        vehicle = Vehicle(vehicle_id, device,client)
+        vehicle = Vehicle(vehicle_id, device,client, self)
         self.vehicles.add(vehicle)
         return vehicle
         pass


### PR DESCRIPTION
Currently, using `Vehicle.disconnect` at any point in your code would cause `Controller.disconnectAll` to crash. This pull request fixes that by adding an optional argument `controller` to the `Vehicle` constructor. The Vehicle then removes itself out of the underlying set for `Controller.vehicles` when `Vehicle.disconnect` is called.

This is not a breaking change as the new argument is optional and if set to None the relevant code will not be executed.